### PR TITLE
Refactor ResponseData constructor to remove 'edited' parameter

### DIFF
--- a/functions/poll_service_java/ResponseData.java
+++ b/functions/poll_service_java/ResponseData.java
@@ -17,7 +17,7 @@ public class ResponseData {
 	private Boolean ended = false;
 	private HashMap<String, Object> result = null;
 
-	ResponseData(ZCRowObject zcRowObject,HashMap<String, Object> votedData,Boolean edited) throws Exception {
+	ResponseData(ZCRowObject zcRowObject,HashMap<String, Object> votedData) throws Exception {
 
 		if(zcRowObject==null){
 			throw new Exception("Error");
@@ -40,7 +40,6 @@ public class ResponseData {
 		result.put("duration", zcRowObject.get("Polls","duration"));
 		result.put("category", zcRowObject.get("Polls","category"));
 		result.put("votes", zcRowObject.get("Polls","votes"));
-		result.put("edited", edited);
 		result.putAll(votedData);
 		result.putAll(endedData);
 		

--- a/functions/poll_service_java/ResponseData.java
+++ b/functions/poll_service_java/ResponseData.java
@@ -40,6 +40,7 @@ public class ResponseData {
 		result.put("duration", zcRowObject.get("Polls","duration"));
 		result.put("category", zcRowObject.get("Polls","category"));
 		result.put("votes", zcRowObject.get("Polls","votes"));
+		result.put("edited", edited);
 		result.putAll(votedData);
 		result.putAll(endedData);
 		


### PR DESCRIPTION
Changes

---

<!-- kody-pr-summary:start -->
Refactored the `ResponseData` constructor by removing the `edited` boolean parameter. Consequently, the `edited` status is no longer added to the `result` map within the `ResponseData` object.
<!-- kody-pr-summary:end -->