### PR TITLE
Change parameter type from HttpServletRequest to ServletRequest

### DIFF
--- a/functions/poll_service_java/Service.java
+++ b/functions/poll_service_java/Service.java
@@ -42,7 +42,7 @@ public class Service implements CatalystAdvancedIOHandler {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void runner(HttpServletRequest request, HttpServletResponse response) throws Exception {
+	public void runner(ServletRequest request, HttpServletResponse response) throws Exception {
 		try {
 			String url = request.getRequestURI();
 			String method = request.getMethod();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
The `runner` method in `Service.java` has been updated to accept `ServletRequest` instead of `HttpServletRequest` as its first parameter. This change generalizes the type of request the method can process.
<!-- kody-pr-summary:end -->